### PR TITLE
fix: `Vue.use` doesn't work

### DIFF
--- a/templates/src/index.js
+++ b/templates/src/index.js
@@ -1,16 +1,12 @@
 // Import vue component
 import Component from './{{componentName}}.vue'
 
-// install function executed by Vue.use()
-export function install(Vue) {
-  if (install.installed) return
-  install.installed = true
-  Vue.component('{{componentNamePascal}}', Component)
-}
-
-// Create module definition for Vue.use()
-const plugin = {
-  install
+// `Vue.use` automatically prevents you from using
+// the same plugin more than once,
+// so calling it multiple times on the same plugin
+// will install the plugin only once
+Component.install = Vue => {
+  Vue.component(Component.name, Component)
 }
 
 // To auto-install when vue is found
@@ -21,7 +17,7 @@ if (typeof window !== 'undefined') {
   GlobalVue = global.Vue
 }
 if (GlobalVue) {
-  GlobalVue.use(plugin)
+  GlobalVue.use(Component)
 }
 
 // To allow use as module (npm/webpack/etc.) export component


### PR DESCRIPTION
close #89


<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits

- feat: A new feature 
- fix: A bug fix
- docs: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing or correcting existing tests
- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

## Why

修复无法使用 Vue.use 去注册组件

## How

1. 参考 element-ui 的组件单独注册方式
https://github.com/ElemeFE/element/blob/dev/packages/button/index.js

2. 因为组件本身的 name 已经是 PascalCase, 直接引用.

3. Vue 本身已经有防止多次注册机制

> Vue.use 会自动阻止多次注册相同插件，届时即使多次调用也只会注册一次该插件。

## Test

使用脚手架生成新组建 my-comp, 打包出 dist, 引入 dist 包, 运行看情况.

1. 使用  Vue.use

![20191009173714](https://user-images.githubusercontent.com/53422750/66475435-e6042900-eac5-11e9-99c6-0765b07eaf47.jpg)

2. 使用 Vue.component 注册组件

![image](https://user-images.githubusercontent.com/53422750/66477721-4a75b700-eacb-11e9-9316-6172a88373a1.png)

