### PR TITLE
chore: dynamic org name and repo name in travis

### DIFF
--- a/templates/notify.sh
+++ b/templates/notify.sh
@@ -5,12 +5,16 @@ then
   exit 1
 fi
 
-git remote add github https://$GITHUB_TOKEN@github.com/{{ownerName}}/{{componentName}}.git > /dev/null 2>&1
+ORG_NAME=$(cut -d '/' -f 1 <<< "$TRAVIS_REPO_SLUG")
+
+REPO_NAME=$(cut -d '/' -f 2 <<< "$TRAVIS_REPO_SLUG")
+
+git remote add github https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG.git > /dev/null 2>&1
 git push github HEAD:master --follow-tags
 
 GREN_GITHUB_TOKEN=$GITHUB_TOKEN yarn release
 
-url=https://api.github.com/repos/{{ownerName}}/{{componentName}}/releases/latest
+url=https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/latest
 resp_tmp_file=resp.tmp
 
 curl -H "Authorization: token $GITHUB_TOKEN" $url > $resp_tmp_file
@@ -19,7 +23,7 @@ html_url=$(sed -n 5p $resp_tmp_file | sed 's/\"html_url\"://g' | awk -F '"' '{pr
 body=$(grep body < $resp_tmp_file | sed 's/\"body\"://g;s/\"//g')
 version=$(echo $html_url | awk -F '/' '{print $NF}')
 
-msg='{"msgtype": "markdown", "markdown": {"title": "{{componentName}}更新", "text": "@所有人\n# [{{componentName}}('$version')]('$html_url')\n'$body'"}}'
+msg='{"msgtype": "markdown", "markdown": {"title": "$REPO_NAME更新", "text": "@所有人\n# [$REPO_NAME('$version')]('$html_url')\n'$body'"}}'
 
 curl -X POST https://oapi.dingtalk.com/robot/send\?access_token\=$DINGTALK_ROBOT_TOKEN -H 'Content-Type: application/json' -d "$msg"
 


### PR DESCRIPTION
## Why
I just want to copy the notify.sh anywhere for travis ci

## How
1. Get $TRAVIS_REPO_SLUG env variable in Travis-ci
https://docs.travis-ci.com/user/environment-variables/
![image](https://user-images.githubusercontent.com/27187946/75603879-e56c3d80-5b0d-11ea-90be-4aec3b1536b6.png)

2. Cut $TRAVIS_REPO_SLUG into ORG_NAME and REPO_NAME

## Test
![image](https://user-images.githubusercontent.com/27187946/75603898-10569180-5b0e-11ea-8971-e6fa20c6f4b2.png)

