### PR TITLE
feat: 生成 .d.ts 和 修改默认分支为 main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 .DS_Store
 v-test
+package-lock.json

--- a/init.js
+++ b/init.js
@@ -76,7 +76,8 @@ if (!isUpgrade()) {
     patterns: {
       gitignore: '.gitignore',
       '_package.json': 'package.json',
-      'src/component.vue': `src/${componentName}.vue`
+      'src/component.vue': `src/${componentName}.vue`,
+      'src/component.d.ts': `src/${componentName}.d.ts`
     }
   })
 

--- a/templates/.travis.yml
+++ b/templates/.travis.yml
@@ -1,6 +1,6 @@
 branches:
   only:
-    - master
+    - main
 language: node_js
 node_js:
 - lts/*
@@ -20,7 +20,11 @@ deploy:
   github-token: $GITHUB_TOKEN
   skip-cleanup: true
   keep-history: true
+  on:
+    branch: main
 - provider: npm
   email: levy9527@qq.com # use your own email
   api_key: $NPM_TOKEN
   skip-cleanup: true
+  on:
+    branch: main

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,9 +1,9 @@
 # {{componentName}}
 
-[![Build Status](https://badgen.net/travis/{{ownerName}}/{{componentName}}/master)](https://travis-ci.com/{{ownerName}}/{{componentName}})
+[![Build Status](https://badgen.net/travis/{{ownerName}}/{{componentName}}/main)](https://travis-ci.com/{{ownerName}}/{{componentName}})
 [![NPM Download](https://badgen.net/npm/dm/@{{ownerNameLowerCase}}/{{componentName}})](https://www.npmjs.com/package/@{{ownerNameLowerCase}}/{{componentName}})
 [![NPM Version](https://badge.fury.io/js/%40{{ownerNameLowerCase}}%2F{{componentName}}.svg)](https://www.npmjs.com/package/@{{ownerNameLowerCase}}/{{componentName}})
-[![NPM License](https://badgen.net/npm/license/@{{ownerNameLowerCase}}/{{componentName}})](https://github.com/{{ownerName}}/{{componentName}}/blob/master/LICENSE)
+[![NPM License](https://badgen.net/npm/license/@{{ownerNameLowerCase}}/{{componentName}})](https://github.com/{{ownerName}}/{{componentName}}/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/{{ownerName}}/{{componentName}}/pulls)
 [![Automated Release Notes by gren](https://img.shields.io/badge/%F0%9F%A4%96-release%20notes-00B2EE.svg)](https://github-tools.github.io/github-release-notes/)
 
@@ -53,7 +53,7 @@ For those who are interested in contributing to this project, such as:
 - fix a bug
 - implement a new feature
 
-Please refer to our [contributing guide](https://github.com/FEMessage/.github/blob/master/CONTRIBUTING.md).
+Please refer to our [contributing guide](https://github.com/FEMessage/.github/blob/main/CONTRIBUTING.md).
 
 [⬆ Back to Top](#table-of-contents)
 

--- a/templates/_package.json
+++ b/templates/_package.json
@@ -23,6 +23,7 @@
   "browser": {
     "./sfc": "src/{{componentName}}.vue"
   },
+  "types": "src/{{componentName}}.d.ts",
   "scripts": {
     "dev": "vue-styleguidist server",
     "test": "jest --verbose",

--- a/templates/gitignore
+++ b/templates/gitignore
@@ -17,3 +17,5 @@ docs/*.ttf
 *.njsproj
 *.sln
 .env
+
+package-lock.json

--- a/templates/notify.sh
+++ b/templates/notify.sh
@@ -11,9 +11,9 @@ ORG_NAME=$(echo "$TRAVIS_REPO_SLUG" | cut -d '/' -f 1)
 REPO_NAME=$(echo "$TRAVIS_REPO_SLUG" | cut -d '/' -f 2)
 
 echo "2/5: pushing commit and tag to github"
-# 该命令很可能报错，但不影响实际进行，因而不能简单地在脚本开头 set -e 
+# 该命令很可能报错，但不影响实际进行，因而不能简单地在脚本开头 set -e
 git remote add github https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG.git > /dev/null 2>&1
-git push github HEAD:master --follow-tags
+git push github HEAD:main --follow-tags
 
 echo "3/5: generating github release notes"
 GREN_GITHUB_TOKEN=$GITHUB_TOKEN yarn release

--- a/templates/src/component.d.ts
+++ b/templates/src/component.d.ts
@@ -1,0 +1,60 @@
+import Vue, {VueConstructor} from 'vue'
+
+/**
+ * @FYI https://www.yuque.com/docs/share/a72a1b84-c0e4-4bd5-853f-6711cb08a507
+ */
+declare module '@{{ownerNameLowerCase}}/{{componentName}}' {
+  class VueComponent extends Vue {
+    static install(vue: typeof Vue): void
+  }
+
+  type CombinedVueInstance<
+    Instance extends Vue,
+    Data,
+    Methods,
+    Computed,
+    Props
+  > = Data & Methods & Computed & Props & Instance
+
+  type ExtendedVue<
+    Instance extends Vue,
+    Data,
+    Methods,
+    Computed,
+    Props
+  > = VueConstructor<
+    CombinedVueInstance<Instance, Data, Methods, Computed, Props> & Vue
+  >
+
+  type Combined<Data, Methods, Computed, Props> = Data &
+    Methods &
+    Computed &
+    Props
+
+  type {{componentNamePascal}}Data = {}
+
+  type {{componentNamePascal}}Methods = {}
+
+  type {{componentNamePascal}}Computed = {}
+
+  type {{componentNamePascal}}Props = {}
+
+  type {{componentNamePascal}} = Combined<
+    {{componentNamePascal}}Data,
+    {{componentNamePascal}}Methods,
+    {{componentNamePascal}}Computed,
+    {{componentNamePascal}}Props
+  >
+
+  export interface {{componentNamePascal}}Type extends VueComponent, {{componentNamePascal}} {}
+
+  const {{componentNamePascal}}Construction: ExtendedVue<
+    Vue,
+    {{componentNamePascal}}Data,
+    {{componentNamePascal}}Methods,
+    {{componentNamePascal}}Computed,
+    {{componentNamePascal}}Props
+  >
+
+  export default {{componentNamePascal}}Construction
+}


### PR DESCRIPTION
## Why
1. 生成 .d.ts 模板，方便编写类型声明文件
2. GitHub 默认分支已经改为 `main`，分支指向也应指向 `main`

## How
1. 类型声明文件与组件名同名
2. travis-ci 的触发分支默认为 master，需要手动改为 `main`